### PR TITLE
[Fix] Keyboard listener warning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,8 @@
 - [ ] i18n
 - [ ] a11y
 
+### Summary
+
 <!-- Please replace {Please write here ...} with something useful -->
 
 {Please write here what's the main purpose of this PR}

--- a/lib/__tests__/utils/functions.js
+++ b/lib/__tests__/utils/functions.js
@@ -541,8 +541,8 @@ describe('Test the "buildShareURI" function', () => {
 
   it('Returns an custom URI string for an object with a proper id', () => {
     const id = getRandInt(10000, 99999)
-    expect(buildShareURI({ id }, false)).toEqual(`litten://litten/${id}`)
-    expect(buildShareURI({ id }, true)).toEqual(
+    expect(buildShareURI({ id }, false)).toBe(`litten://litten/${id}`)
+    expect(buildShareURI({ id }, true)).toBe(
       `https://litten.app/open/litten/${id}`,
     )
   })

--- a/lib/store/configure-store.js
+++ b/lib/store/configure-store.js
@@ -3,7 +3,7 @@
  * @flow
  */
 
-import type { Persistor } from '../../node_modules/redux-persist/lib/types'
+import type { Persistor } from 'redux-persist/lib/types'
 import { APP_IS_DEV } from 'utils/env'
 import { createStore, type Store } from 'redux'
 import { persistStore, persistReducer } from 'redux-persist'

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-flowtype": "^8.0.3",
-    "eslint-plugin-jest": "^25.3.0",
+    "eslint-plugin-jest": "^25.3.2",
     "faker": "^5.4.0",
     "firebase-admin": "^10.0.1",
     "firebase-tools": "^10.0.1",

--- a/patches/react-native-gifted-chat+0.16.3.patch
+++ b/patches/react-native-gifted-chat+0.16.3.patch
@@ -10,3 +10,41 @@ index 414eefc..7cf98e3 100644
    renderChatFooter?: () => React.Node,
    renderInputToolbar?: InputToolbarProps => React.Node,
    renderComposer?: ComposerProps => React.Node,
+diff --git a/node_modules/react-native-gifted-chat/lib/MessageContainer.js b/node_modules/react-native-gifted-chat/lib/MessageContainer.js
+index 193772a..79bd4af 100644
+--- a/node_modules/react-native-gifted-chat/lib/MessageContainer.js
++++ b/node_modules/react-native-gifted-chat/lib/MessageContainer.js
+@@ -52,21 +52,24 @@ export default class MessageContainer extends React.PureComponent {
+         this.state = {
+             showScrollBottom: false,
+         };
++        this.kbEventWillShow = null;
++        this.kbEventDidShow = null;
++        this.kbEventWillHide = null;
++        this.kbEventDidHide = null;
+         this.attachKeyboardListeners = () => {
+             const { invertibleScrollViewProps: invertibleProps } = this.props;
+             if (invertibleProps) {
+-                Keyboard.addListener('keyboardWillShow', invertibleProps.onKeyboardWillShow);
+-                Keyboard.addListener('keyboardDidShow', invertibleProps.onKeyboardDidShow);
+-                Keyboard.addListener('keyboardWillHide', invertibleProps.onKeyboardWillHide);
+-                Keyboard.addListener('keyboardDidHide', invertibleProps.onKeyboardDidHide);
++                this.kbEventWillShow = Keyboard.addListener('keyboardWillShow', invertibleProps.onKeyboardWillShow);
++                this.kbEventDidShow = Keyboard.addListener('keyboardDidShow', invertibleProps.onKeyboardDidShow);
++                this.kbEventWillHide = Keyboard.addListener('keyboardWillHide', invertibleProps.onKeyboardWillHide);
++                this.kbEventDidHide = Keyboard.addListener('keyboardDidHide', invertibleProps.onKeyboardDidHide);
+             }
+         };
+         this.detachKeyboardListeners = () => {
+-            const { invertibleScrollViewProps: invertibleProps } = this.props;
+-            Keyboard.removeListener('keyboardWillShow', invertibleProps.onKeyboardWillShow);
+-            Keyboard.removeListener('keyboardDidShow', invertibleProps.onKeyboardDidShow);
+-            Keyboard.removeListener('keyboardWillHide', invertibleProps.onKeyboardWillHide);
+-            Keyboard.removeListener('keyboardDidHide', invertibleProps.onKeyboardDidHide);
++            this.kbEventWillShow && this.kbEventWillShow.remove();
++            this.kbEventDidShow && this.kbEventDidShow.remove();
++            this.kbEventWillHide && this.kbEventWillHide.remove();
++            this.kbEventDidHide && this.kbEventDidHide.remove();
+         };
+         this.renderTypingIndicator = () => {
+             if (Platform.OS === 'web') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6115,10 +6115,10 @@ eslint-plugin-jest@22.4.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz#a5fd6f7a2a41388d16f527073b778013c5189a9c"
   integrity sha512-gcLfn6P2PrFAVx3AobaOzlIEevpAEf9chTpFZz7bYfc7pz8XRv7vuKTIE4hxPKZSha6XWKKplDQ0x9Pq8xX2mg==
 
-eslint-plugin-jest@^25.3.0:
-  version "25.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.3.0.tgz#6c04bbf13624a75684a05391a825b58e2e291950"
-  integrity sha512-79WQtuBsTN1S8Y9+7euBYwxIOia/k7ykkl9OCBHL3xuww5ecursHy/D8GCIlvzHVWv85gOkS5Kv6Sh7RxOgK1Q==
+eslint-plugin-jest@^25.3.2:
+  version "25.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-25.3.2.tgz#702801e37c502546fe4c4986888720f6eed3b129"
+  integrity sha512-1aPC7RRJkMCNgklHMDECw8fnzag3JBH53LaxmFkDTR7+PfMCO5V6f8XFRHoT2I+Fr4pVO9cPdRGlf7/haB2O5Q==
   dependencies:
     "@typescript-eslint/experimental-utils" "^5.0.0"
 


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] DevOps
- [ ] i18n
- [ ] a11y

### Summary

<!-- Please replace {Please write here ...} with something useful -->

Fixes the deprecation warnings:

```txt
EventEmitter.removeListener('keyboardWillShow', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.
```

### Change description

<!-- Please replace {Please write here ...} with something useful -->

- Adds a monkey patch to fix https://github.com/FaridSafi/react-native-gifted-chat/issues/2112

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [ ] Tests added
- [x] Tests passed
- [x] Coding style respected
