### PR TITLE
[MOBILE-113] Fix the event listener deprecation warning

### DIFF
--- a/ios/litten/AppDelegate.m
+++ b/ios/litten/AppDelegate.m
@@ -52,7 +52,9 @@ static void InitializeFlipper(UIApplication *application) {
 #ifdef FB_SONARKIT_ENABLED
   InitializeFlipper(application);
 #endif
-  [FIRApp configure];
+  if(![FIRApp defaultApp]) {
+    [FIRApp configure];
+  }
 
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge

--- a/lib/__mocks__/react-native-localize.ts
+++ b/lib/__mocks__/react-native-localize.ts
@@ -39,7 +39,9 @@ const uses24HourClock = () => true
 const usesMetricSystem = () => true
 
 const addEventListener = jest.fn()
+
 const removeEventListener = jest.fn()
+
 export {
   findBestAvailableLanguage,
   getLocales,

--- a/lib/hooks/use-app-state.ts
+++ b/lib/hooks/use-app-state.ts
@@ -1,12 +1,16 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { AppState } from 'react-native'
 
 const useAppState = (callbackFn: (state: string) => void): void => {
+  const eventListenerRef = useRef(null)
+
   useEffect(() => {
-    AppState.addEventListener('change', callbackFn)
+    eventListenerRef.current = AppState.addEventListener('change', callbackFn)
 
     return () => {
-      AppState.removeEventListener('change', callbackFn)
+      if (typeof eventListenerRef?.current?.remove === 'function') {
+        eventListenerRef.current.remove()
+      }
     }
   }, [callbackFn])
 }

--- a/lib/screens/select-location/main.tsx
+++ b/lib/screens/select-location/main.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useNavigation } from '@react-navigation/native'
 import { useDispatch } from 'react-redux'
-import SelectLocationMapScreen from './map'
+import SelectLocationMapScreen from '@screens/select-location/map'
 
 const SelectLocationIndexScreen = ({
   route: {

--- a/lib/screens/select-location/map.tsx
+++ b/lib/screens/select-location/map.tsx
@@ -113,6 +113,7 @@ const SelectLocationMapScreen = ({
     setGoneToSettings(true)
     openSetting()
   }, [])
+
   useAppState((appState) => {
     if (goneToSettings && appState === 'active') {
       setGoneToSettings(false)

--- a/lib/ui-elements/icon.tsx
+++ b/lib/ui-elements/icon.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import type { FC, ReactNode } from 'react'
 import { View } from 'react-native'
 import { useTheme } from '@hooks'
@@ -23,11 +23,6 @@ type UIIconProps = {
   size: 'mini' | 'small' | 'medium'
   style: any
 }
-
-const areEqual = (prevProps, nextProps) =>
-  prevProps.selected === nextProps.selected &&
-  prevProps.icon === nextProps.icon &&
-  prevProps.IconComponent === nextProps.IconComponent
 
 const UIIcon: (props: UIIconProps) => FC = ({
   circle = false,
@@ -140,4 +135,4 @@ const UIIcon: (props: UIIconProps) => FC = ({
   )
 }
 
-export default memo<UIIconProps>(UIIcon, areEqual)
+export default UIIcon

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "generate-data": "./scripts/generate-data",
     "ios:device:production": "react-native run-ios --configuration Release --device $IOS_DEVICE_NAME",
     "ios:device": "react-native run-ios --device $IOS_DEVICE_NAME",
-    "ios": "react-native run-ios",
+    "ios": "react-native run-ios --simulator $IOS_SIMULATOR_NAME",
     "link:android:litten": "adb shell am start -W -a android.intent.action.VIEW -d \"https://litten.app/open/litten/$LITTEN_UID\"",
     "link:android:verification": "adb shell am start -W -a android.intent.action.VIEW -d \"https://litten.app/open/verification?mode=action&oobCode=code\"",
     "link:ios:litten": "xcrun simctl openurl booted https://litten.app/open/litten/$LITTEN_UID",


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Feature
- [x] Fix #MOBILE-113
- [ ] Refactor
- [ ] DevOps
- [ ] i18n
- [ ] a11y

### Summary

<!-- Please replace {Please write here ...} with something useful -->

The [removeEventListener][removeeventlistener] method is officially deprecated for `AppState`.

### Change description

<!-- Please replace {Please write here ...} with something useful -->

- Replaced the deprecated method with the new recommended subscription return value

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [ ] Tests added
- [x] Tests passed
- [x] Coding style respected

<!-- References -->

[removeeventlistener]: https://reactnative.dev/docs/appstate#removeeventlistener