### PR TITLE
[MOBILE-126] Map screen stuck after permission granted

### DIFF
--- a/lib/config/location/initial-region.ts
+++ b/lib/config/location/initial-region.ts
@@ -1,4 +1,5 @@
 import { Dimensions } from 'react-native'
+import type { Region } from 'react-native-maps'
 
 const { width: wWidth, height: wHeight } = Dimensions.get('window')
 
@@ -12,7 +13,7 @@ export const LONGITUDE_DELTA: number = +(LATITUDE_DELTA * ASPECT_RATIO).toFixed(
   2,
 )
 
-export const initialRegion = {
+export const initialRegion: Region = {
   latitude: null,
   longitude: null,
   latitudeDelta: LATITUDE_DELTA,

--- a/lib/screens/select-location/main.tsx
+++ b/lib/screens/select-location/main.tsx
@@ -2,17 +2,27 @@ import { useCallback } from 'react'
 import { useNavigation } from '@react-navigation/native'
 import { useDispatch } from 'react-redux'
 import SelectLocationMapScreen from '@screens/select-location/map'
+import type { DBCoordinateObject, DBLocationObject } from '@db/schemas/location'
+
+export type SelectLocationIndexScreenProps = {
+  route: {
+    params: {
+      initialCoordinates: DBCoordinateObject
+      dispatchToAction: string
+    }
+  }
+}
 
 const SelectLocationIndexScreen = ({
   route: {
     params: { initialCoordinates, dispatchToAction },
   },
-}) => {
+}: SelectLocationIndexScreenProps) => {
   const dispatch = useDispatch()
   const navigation = useNavigation()
 
   const setLocationToAction = useCallback(
-    (payload) =>
+    (payload: DBLocationObject) =>
       dispatch({
         type: dispatchToAction,
         payload,
@@ -21,7 +31,7 @@ const SelectLocationIndexScreen = ({
   )
 
   const onLocationChange = useCallback(
-    (newLoc) => {
+    (newLoc: DBLocationObject) => {
       if (dispatchToAction && newLoc) {
         setLocationToAction(newLoc)
       }

--- a/lib/screens/select-location/main.tsx
+++ b/lib/screens/select-location/main.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useNavigation } from '@react-navigation/native'
 import { useDispatch } from 'react-redux'
 import SelectLocationMapScreen from '@screens/select-location/map'
@@ -15,11 +15,16 @@ export type SelectLocationIndexScreenProps = {
 
 const SelectLocationIndexScreen = ({
   route: {
-    params: { initialCoordinates, dispatchToAction },
+    params: { initialCoordinates: propsInitialCoordinates, dispatchToAction },
   },
 }: SelectLocationIndexScreenProps) => {
   const dispatch = useDispatch()
   const navigation = useNavigation()
+
+  const initialCoordinates = useMemo(
+    () => propsInitialCoordinates,
+    [propsInitialCoordinates],
+  )
 
   const setLocationToAction = useCallback(
     (payload: DBLocationObject) =>

--- a/lib/screens/select-location/map.tsx
+++ b/lib/screens/select-location/map.tsx
@@ -32,7 +32,7 @@ const SelectLocationMapScreen = ({
   })
   const [coordinates, setCoordinates] = useState(initialCoordinates)
 
-  const mapRef = useRef(null)
+  const mapRef = useRef<MapView>(null)
 
   const handleOnMapReady = useCallback(() => {
     setIsLoading(false)
@@ -138,21 +138,25 @@ const SelectLocationMapScreen = ({
         const isPermissionGranted = await hasLocationPermission()
 
         if (isPermissionGranted) {
-          setCurrentLocation()
           setHasPermission(isPermissionGranted)
         }
       }
     },
-    [goneToSettings, setCurrentLocation],
+    [goneToSettings],
   )
 
   useAppState(onStateChange)
 
   useEffect(() => {
-    setCurrentLocation()
     checkPermission()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => {
+    if (hasPermission) {
+      setCurrentLocation()
+    }
+  }, [hasPermission, setCurrentLocation])
 
   if (hasPermission === false) {
     return (

--- a/lib/utils/setup.ts
+++ b/lib/utils/setup.ts
@@ -22,7 +22,7 @@ import type { BasicUser } from '@model/types/user'
 import type { BasicLitten } from '@model/types/litten'
 import appConfig from '../../app.json'
 
-export const openSetting = () => {
+export const openSettings = () => {
   Linking.openSettings().catch(() => {
     Toast.show(translate('feedback.system.cantOpenSettings'))
   })
@@ -48,7 +48,7 @@ export const hasLocationPermissionIOS = async (): Promise<boolean> => {
       [
         {
           text: translate('feedback.system.goToSettings'),
-          onPress: openSetting,
+          onPress: openSettings,
         },
         {
           text: translate('feedback.system.dontUseLocation'),


### PR DESCRIPTION
<!-- Thank you for your contribution ! -->

### Request type

<!-- (add an `x` to `[ ]` if applicable and the issue number if available) -->

- [ ] Feature
- [x] Fix
- [ ] Tests
- [ ] Refactor
- [ ] DevOps
- [ ] i18n
- [ ] a11y
- [ ] Documentation
- [ ] Release

### Summary

<!-- Please replace {Please write here ...} with something useful -->

Map screen doesn't update _immediately_ after permission granted, but remains in a _loading_ state. Seems to affect **Android** only.

### Change description

<!-- Please replace {Please write here ...} with something useful -->

- Added typings to the maps screen
- Renamed the `openSetting` helper function to `openSettings` (iOS)
- Refactored the components to reduce the number of rendering, fixing the calls to `checkPermission` and solving the issue

### Check lists

<!-- (add an `x` to `[ ]` if applicable) -->

- [ ] Added tests
- [x] Passed tests
- [x] Coding style respected

<!-- References -->
